### PR TITLE
Adding resetMonitor end point.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ options:
 
 ### cl.deleteMonitor(id, fn(err))
 
-Delete the monitor with the given id
+options:
+
+ - monitorID - required
+
+### cl.resetMonitor(id, fn(err))
+
+options:
+
+ - monitorID - required
 
 
 ### cl.getAlertContacts(options, fn(err, alertContacts))

--- a/index.js
+++ b/index.js
@@ -106,6 +106,10 @@ Client.prototype.deleteMonitor = function (id, callback) {
   return this.request('deleteMonitor', { monitorID: id }).nodeify(callback);
 };
 
+Client.prototype.resetMonitor = function (id, callback) {
+  return this.request('resetMonitor', { monitorID: id }).nodeify(callback);
+};
+
 Client.prototype.getAlertContacts = function (options, callback) {
   if (typeof options === 'function') {
     callback = options;

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,15 @@ cl.getMonitors({customUptimeRatio: [1, 7, 30]}, function (err, res) {
   assert(Array.isArray(res));
   assert(res.length === 1);
   assert(res[0].id === '776540955');
-  console.log(res);
-  console.log('tests passed');
-  process && process.exit && process.exit(0);
+  console.log('getMonitors', res);
+  console.log('getMonitors passed');
 });
+
+cl.resetMonitor('776540955', function (err, res) {
+  if (err) throw err;
+  assert(res.stat === 'ok');
+  console.log('resetMonitor', res);
+  console.log('resetMonitor passed');
+});
+
+process && process.exit && process.exit(0);


### PR DESCRIPTION
This adds the `resetMonitor` end point which resets stats and response time data for a specific monitor. Updated the readme with this info and tweaked the deleteMonitor to match the format from the others. Added a test for resetMonitor as well.

I'm going to be using this for a project so will most likely add the other missing end points as well.
